### PR TITLE
Initialize done and doLater values to false

### DIFF
--- a/17-tasks-ui/Final/lib/database/supa_database.dart
+++ b/17-tasks-ui/Final/lib/database/supa_database.dart
@@ -50,8 +50,13 @@ class SupaDatabaseRepository extends ChangeNotifier {
   }
 
   Future<Task?> addTask(Task task) async {
+    final newTask = Task (
+      name: task.name,
+      done: false,
+      doLater: false
+    );
     final data = await addDataToTable(
-        taskTable, taskToDatabaseJson(task, client.auth.currentUser!.id));
+        taskTable, taskToDatabaseJson(newTask, client.auth.currentUser!.id));
     if (data != null && data.isNotEmpty) {
       notifyListeners();
       return Task.fromJson(data[0]);


### PR DESCRIPTION
PROBLEM: Starting from Chapter 17, tasks that were made with null values for 'done' and 'doLater' are not displayed in the app simulator.

SOLUTION: Create a new task, initializing the new task's 'done' and 'doLater' values to false before adding the Supabase table. 